### PR TITLE
[1.2.0] Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0
+
+* Fixed issue with the `restart` method.
+* Cleanup and reformat internal code.
+* **BREAKING CHANGE:**  
+  * Temporarily removed the `pause` and `resume` methods.
+  * The `debugMode` in the `create()` and `createOwnIsolate()` methods was refactored to **named optional parameters**.
+
 ## 1.1.0+1
 
 * Remove flutter dependencies to support dart native

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Isolate Contactor
 
-An easy way to create a new isolate and comunicate with it and support sending values between main and child isolate multiple times via `stream`. So you can build your `widget` with `StreamBuilder` and always listen to the value from your `isolate`.
+An easy way to create a new isolate, keep it running and comunicate with it. It supports sending values between main and child isolate multiple times via `stream`, so you can build your `widget` with `StreamBuilder` and always listen to the new value from your `isolate`.
 
 This package is different from the `compute` method, IsolateContactor allows the isolate to run, send, receive data data until you terminate it. It'll  save a lot of starting time.
 
@@ -11,7 +11,7 @@ There are multiple ways to use this package, the only thing to notice that the `
 ### Create IsolateContactor instance
 
 ``` dart
-IsolateContactor isolateContactor = await IsolateContactor.create(fibonacci);
+IsolateContactor isolateContactor = await IsolateContactor.create(<function>);
 ```
 
 ### Listen to the result of the isolate
@@ -77,7 +77,7 @@ You just need to create a function of this form:
 ``` dart
 dynamic function(dynamic param) {
   // do something
-  return something; // <-- This result will be send back to your `onMessage` in main isolate.
+  return something; // <-- This result will be sent back to your `onMessage` in main isolate.
 }
 ```
 
@@ -86,7 +86,7 @@ or
 ``` dart
 Future<dynamic> function(dynamic param) async {
   // do something
-  return something; // <-- This result will be send back to your `onMessage` in main isolate.
+  return something; // <-- This result will be sent back to your `onMessage` in main isolate.
 }
 ```
 
@@ -150,7 +150,7 @@ dynamic fibonacci(dynamic n) {
   return fibonacci(n - 2) + fibonacci(n - 1);
 }
 
-// multi parameters as an dynamic
+// multi parameters as a dynamic
 dynamic subtract(dynamic n) => n[1] - n[0];
 ```
 
@@ -161,7 +161,10 @@ You just need to create a function of this form:
 
 ``` dart
 void isolateFunction(dynamic params) {
+  // Create IsolateContactor controller from params
   final channel = IsolateContactorController(params);
+
+  // Listen to to the `message` sent from main process
   channel.onIsolateMessage.listen((message) {
     // Do your stuff here
     
@@ -171,8 +174,8 @@ void isolateFunction(dynamic params) {
 }
 ```
 
-And use `IsolateContactor.createOwnIsolate(isolateFunction)` and the package will do anything else for you. Please remember that you need to create exactly the same form to make it works.
-This is the example:
+And use `IsolateContactor.createOwnIsolate(isolateFunction)` and the package will do anything else for you. Please remember that you need to create exactly the same form of the function to make it works.
+This is an example:
 
 ``` dart
 main() async {
@@ -204,10 +207,9 @@ void isolateFunction(dynamic params) {
 dynamic add(dynamic a, dynamic b) => a + b;
 ```
 
-## Notice
+## Limitation
 
-- This package is still in the early stages of development.
-- Support web with limited features because the package use `Future` for Web platform.
+Support web platform with limited features. The package use `Future` to provide the same features to Isolate but it currently doesn't have `pause`, `resume`, `restart` methods. I'll try to bring the same action with Isolate as much as possible in the next version.
 
 ## Contributions
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -102,10 +102,12 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> initial() async {
-    isolateContactor1 = await IsolateContactor.create(fibonacciFuture);
-    isolateContactor2 =
-        await IsolateContactor.createOwnIsolate(isolateFunction);
-    isolateContactor3 = await IsolateContactor.create(fibonacciRescusiveFuture);
+    isolateContactor1 =
+        await IsolateContactor.create(fibonacciFuture, debugMode: true);
+    isolateContactor2 = await IsolateContactor.createOwnIsolate(isolateFunction,
+        debugMode: true);
+    isolateContactor3 = await IsolateContactor.create(fibonacciRescusiveFuture,
+        debugMode: true);
     setState(() => isLoading = false);
   }
 
@@ -179,6 +181,14 @@ class _MyAppState extends State<MyApp> {
                           child: const Text('Restart isolate 1'),
                         ),
                       ),
+                      ListTile(
+                        title: ElevatedButton(
+                          onPressed: () {
+                            isolateContactor1.terminate();
+                          },
+                          child: const Text('Terminate isolate 1'),
+                        ),
+                      ),
                       StreamBuilder(
                         stream: isolateContactor2.onMessage,
                         builder: (context, snapshot) {
@@ -205,6 +215,14 @@ class _MyAppState extends State<MyApp> {
                               ),
                             );
                           }),
+                      ListTile(
+                        title: ElevatedButton(
+                          onPressed: () {
+                            isolateContactor2.restart();
+                          },
+                          child: const Text('Restart isolate 2'),
+                        ),
+                      ),
                       ListTile(
                         title: ElevatedButton(
                           onPressed: () {
@@ -239,6 +257,14 @@ class _MyAppState extends State<MyApp> {
                               ),
                             );
                           }),
+                      ListTile(
+                        title: ElevatedButton(
+                          onPressed: () {
+                            isolateContactor3.restart();
+                          },
+                          child: const Text('Restart isolate 3'),
+                        ),
+                      ),
                       ListTile(
                         title: ElevatedButton(
                           onPressed: () {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0+1"
+    version: "1.1.0+1"
   lints:
     dependency: transitive
     description:

--- a/lib/src/isolate_contactor.dart
+++ b/lib/src/isolate_contactor.dart
@@ -9,10 +9,10 @@ abstract class IsolateContactor {
   ///
   /// [function] must be static or top-level function.
   /// [debugMode] allow printing debug data in console. Default is set to false.
-  static Future<IsolateContactor> create([
-    dynamic Function(dynamic)? function,
+  static Future<IsolateContactor> create(
+    dynamic Function(dynamic) function, {
     bool debugMode = false,
-  ]) async {
+  }) async {
     return IsolateContactorInternal.create(
         function: function, debugMode: debugMode);
   }
@@ -24,10 +24,10 @@ abstract class IsolateContactor {
   /// [isolateParams] is the list of parameters that you want to add to your [isolateFunction]
   /// [debugMode] allow printing debug data in console. Default is set to false.
   static Future<IsolateContactor> createOwnIsolate(
-    dynamic Function(dynamic) isolateFunction, [
+    dynamic Function(dynamic) isolateFunction, {
     dynamic isolateParams,
     bool debugMode = false,
-  ]) async {
+  }) async {
     return IsolateContactorInternal.createOwnIsolate(
         isolateFunction: isolateFunction,
         isolateParams: isolateParams,
@@ -47,19 +47,9 @@ abstract class IsolateContactor {
   /// Get current computing state of the isolate
   bool get isComputing => throw UnimplementedError();
 
-  /// Pause the isolate
-  ///
-  /// This method is not available in Web platform at the moment
-  void pause() => throw UnimplementedError();
-
-  /// Resume the isolate
-  ///
-  /// This method is not available in Web platform at the moment
-  void resume() => throw UnimplementedError();
-
   /// Restart the paused isolate
   ///
-  /// This method is not available in Web platform at the moment
+  /// This method is not available on Web platform at the moment
   Future<void> restart() async => throw UnimplementedError();
 
   /// Close current isolate, the same behavior with [dispose]

--- a/lib/src/isolate_contactor_controller.dart
+++ b/lib/src/isolate_contactor_controller.dart
@@ -8,7 +8,11 @@ abstract class IsolateContactorController {
   factory IsolateContactorController(dynamic params) =
       IsolateContactorControllerIpl;
 
-  StreamController get controller => throw UnimplementedError();
+  /// Get current controller. This method only needs for internal use only
+  ///
+  /// [StreamController] on Web platform
+  /// [IsolateChannel] on other platforms
+  dynamic get controller => throw UnimplementedError();
 
   /// Listen to result of the isolate
   Stream get onMessage => throw UnimplementedError();

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,10 +4,10 @@ import 'isolate_contactor_controller.dart';
 enum ComputeState { computing, computed }
 
 /// Port for sending message
-enum IsolatePort { main, child, debug }
+enum IsolatePort { main, isolate }
 
 /// Get data with port
-dynamic getIsolatePortMessage(IsolatePort toPort, dynamic rawMessage) {
+dynamic getPortMessage(IsolatePort toPort, dynamic rawMessage) {
   try {
     return rawMessage[toPort];
   } catch (_) {}
@@ -18,6 +18,7 @@ dynamic getIsolatePortMessage(IsolatePort toPort, dynamic rawMessage) {
 void internalIsolateFunction(dynamic params) {
   var channel = IsolateContactorController(params);
   channel.onIsolateMessage.listen((message) {
+    print('[Isolate Contactor Isolate]: $message');
     try {
       (params[0](message) as Future).then((value) {
         channel.sendResult(value);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isolate_contactor
 description: An easy way to create a new isolate, keep it running and comunicate with it. It supports sending values between main and child isolate multiple times via stream.
-version: 1.1.0+1
+version: 1.2.0
 homepage: https://github.com/fatasin/isolate_contactor
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: isolate_contactor
-description: An easy way to create a new isolate and comunicate with it and support sending values between main and child isolate multiple times via `stream`.
+description: An easy way to create a new isolate, keep it running and comunicate with it. It supports sending values between main and child isolate multiple times via stream.
 version: 1.1.0+1
 homepage: https://github.com/fatasin/isolate_contactor
 


### PR DESCRIPTION
* Fixed issue with the `restart` method.
* Cleanup and reformat internal code.
* **BREAKING CHANGE:**  
  * Temporarily removed the `pause` and `resume` methods.
  * The `debugMode` in the `create()` and `createOwnIsolate()` methods was refactored to **named optional parameters**.